### PR TITLE
Fix exclusions

### DIFF
--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -101,7 +101,7 @@ function M.report()
    local hit0_exclusions =
    {
       { true, "[%w_,='\"%s]+%s*," }, -- "var1 var2," multi columns table stuff
-      { true, "%[%s*[\"'%w_]+%s*%]%s=.+," }, -- "[123] = 23," "[ "foo"] = "asd"," 
+      { true, "%[?%s*[\"'%w_]+%s*%]?%s=.+," }, -- "[123] = 23," "[ "foo"] = "asd"," 
       { true, "[%w_,'\"%s]*function%s*%([%w_,%s%.]*%)" }, -- "1,2,function(...)"
       { true, "local%s+[%w_]+%s*=%s*function%s*%([%w_,%s%.]*%)" }, -- "local a = function(arg1, ..., argN)"
       { true, "[%w%._]+%s*=%s*function%s*%([%w_,%s%.]*%)" }, -- "a = function(arg1, ..., argN)"


### PR DESCRIPTION
Add some exclusions for hits==0:

function assignments:

`local f1 = function(...)`

`f2 = function(...)`

multi-column tables (mainly effects luajit generated cov):

```
    a = {
       1,
       2,
    }
    c = {
       b = 3,
    }
```

Note: The last (multi-column) table entry should have a trailing comma, to be detected as "misleading" hits==0
