### PR TITLE
Avoid outputing the coverage percent as -NaN%

### DIFF
--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -212,7 +212,10 @@ function M.report()
    report:write("\n")
    
    local function write_total(hits, miss, filename)
-      report:write(hits, "\t", miss, "\t", ("%.2f%%"):format(hits/(hits+miss)*100.0), "\t", filename, "\n")
+      local total = hits + miss
+      if total == 0 then total = 1 end
+
+      report:write(hits, "\t", miss, "\t", ("%.2f%%"):format(hits/(total)*100.0), "\t", filename, "\n")
    end
    
    local total_hits, total_miss = 0, 0


### PR DESCRIPTION
If the sum of hits and miss are 0, the percent gets calculated as

```
hits / (hits + miss) * 100
```

Normally this works fine, but if you're just starting a project, you'll get `0/0` which evaluates to `-nan`.  This fixes that by checking if `hits + miss` is `0` and then use `1` so we get `0/1` which evaluates to `0`.
