### PR TITLE
Change. Use `newproxy` gc method to call `on_exit` function.

### DIFF
--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -108,7 +108,8 @@ end
 local function on_exit()
    -- Lua >=5.2 could call __gc when user call os.exit
    -- so this method could be called twice
-   on_exit = function() end
+   if not on_exit then return end
+   on_exit = false
 
    stats.save(data, statsfile)
    stats.stop(statsfile)
@@ -138,7 +139,7 @@ function runner.load_config(configuration)
       error("Expected filename, config table or nil. Got " .. type(configuration))
     end
     runner.configuration = configuration
-    end
+  end
   return runner.configuration
 end
 


### PR DESCRIPTION
Implementation with file has several bugs
- on windows temp directory could be pointed by TEMP or TMP env variable.
- gc method could not remove file because of this file still open
  You could close file just after open it

``` lua
runner.on_exit_trick = io.open(luacovlock, "w")
runner.on_exit_trick:close()
debug.setmetatable(runner.on_exit_trick, { __gc = on_exit } )
```
- If user code in Lua 5.2 calls `os.exit(true)` then on_exit function being called twice and raise error.
