### PR TITLE
Fix for codefromstring issue

### DIFF
--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -47,6 +47,7 @@ local function on_line(_, line_nr)
 
    -- get name of processed file; ignore Lua code loaded from raw strings
    -- unless configuration value codefromstrings is true
+   local name = debug.getinfo(2, "S").source
    if name:match("^@") then
       name = name:sub(2)
    elseif not runner.configuration.codefromstrings then


### PR DESCRIPTION
If codefromstrings configuration option is enabled the runner will
always strip the first character of the filename even if it doesn’t
begin with an @ sign
