### PR TITLE
Improve line exclusion

### DIFF
--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -24,6 +24,7 @@ local fixups = {
    { "<FIELDNAME>", "%[? *[\"'%w_]+ *%]?" }, -- field, possibly like ["this"]
    { " * ", " " }, -- collapse consecutive spacing rules
    { " + *", " +" }, -- collapse consecutive spacing rules
+   { " ", "%s" }, -- accept all whitespace characters as space
 }
 
 --- Utility function to make patterns more readable
@@ -35,8 +36,8 @@ local function fixup(pat)
    return pat
 end
 
-local long_string_1 = "^() *" .. fixup"<FULLID>=<BEGIN_LONG_STRING>$"
-local long_string_2 = "^() *" .. fixup"local <FULLID>=<BEGIN_LONG_STRING>$"
+local long_string_1 = "^()%s*" .. fixup "<FULLID>=<BEGIN_LONG_STRING>$"
+local long_string_2 = "^()%s*" .. fixup "local <FULLID>=<BEGIN_LONG_STRING>$"
 
 local function check_long_string(line, in_long_string, ls_equals, linecount)
    local long_string
@@ -76,7 +77,7 @@ local any_hits_exclusions = {
 
 --- Lines that are only excluded from accounting when they have 0 hits
 local zero_hits_exclusions = {
-   "[%w_,='\" ]+,", -- "var1 var2," multi columns table stuff
+   "[%w_,='\"%s]+,", -- "var1 var2," multi columns table stuff
    fixup "<FIELDNAME>=.+[,;]", -- "[123] = 23," "['foo'] = "asd","
    fixup "<ARGS>*function(<ARGS>)", -- "1,2,function(...)"
    fixup "return <ARGS>*function(<ARGS>)", -- "return 1,2,function(...)"

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -61,7 +61,7 @@ end
 --- Lines that are always excluded from accounting
 local any_hits_exclusions = {
    "", -- Empty line
-   fixup "end[,;)]?", -- Single "end"
+   fixup "end[,;%s%)]*", -- Single "end"
    "else", -- Single "else"
    "repeat", -- Single "repeat"
    "do", -- Single "do"
@@ -87,9 +87,7 @@ local zero_hits_exclusions = {
    fixup "<FULLID>=function(<ARGS>)", -- "a = function(arg1, ..., argN)"
    "break", -- "break" generates no trace in Lua 5.2+
    "{", -- "{" opening table
-   "}", -- "{" closing table
-   fixup "})", -- function closer
-   fixup ")", -- function closer
+   "}?[%s%)]*", -- optional "{" closing table, possibly with several closing parens
 }
 
 local function excluded_(exclusions,line)


### PR DESCRIPTION
* Treat all whitespace characters identically.
* Exclude lines with multiple closing parens, not only with one paren.
* A bit of refactoring.

Some questions:

1. Is there a point in always filtering some lines? Maybe if a line is hit, it makes sense to always report it?
2. Zero hit exclusions `return <ARGS>*function(<ARGS>)` and `<ARGS>*function(<ARGS>)` are broken, they expand into patterns containing `[...]**`, which typically never match. I think these exclusions are invalid anyway, because `<ARGS>` as expressions should always generate a trace.
3. Comment for the first zero hit exclusion says `"var1 var2," multi columns table stuff`, what does that mean? `var1 var2,` can rarely be valid syntax.