### PR TITLE
Simplify lines before applying exclusion rules

### DIFF
--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -57,6 +57,8 @@ local zero_hits_exclusions = {
    fixup "return function(<ARGS>)", -- "return function(arg1, ..., argN)"
    fixup "function(<ARGS>)", -- "function(arg1, ..., argN)"
    fixup "local <ID>=function(<ARGS>)", -- "local a = function(arg1, ..., argN)"
+   fixup "local <ID>='", -- local a = [[
+   fixup "<FULLID>='", -- a.b = [[
    fixup "<FULLID>=function(<ARGS>)", -- "a = function(arg1, ..., argN)"
    "break", -- "break" generates no trace in Lua 5.2+
    "{", -- "{" opening table

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -15,12 +15,11 @@ local fixups = {
    { "=", " ?= ?" }, -- '=' may be surrounded by spaces
    { "(", " ?%( ?" }, -- '(' may be surrounded by spaces
    { ")", " ?%) ?" }, -- ')' may be surrounded by spaces
-   { "<ID>", " ?[%w_]+ ?" }, -- identifier
-   { "<FULLID>", " ?[%w_][%w_%.%[%]]+ ?" }, -- identifier, possibly indexed
+   { "<ID>", "[%w_]+" }, -- identifier
+   { "<FULLID>", "[%w_][%w_%.%[%]]+" }, -- identifier, possibly indexed
    { "<IDS>", "[%w_, ]+" }, -- comma-separated identifiers
    { "<ARGS>", "[%w_, '%.]*" }, -- comma-separated arguments
    { "<FIELDNAME>", "%[? ?['%w_]+ ?%]?" }, -- field, possibly like ["this"]
-   { " [ %?]+", " " }, -- collapse consecutive spacing rules
 }
 
 --- Utility function to make patterns more readable

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -519,4 +519,6 @@ reporter.ReporterBase    = ReporterBase
 
 reporter.DefaultReporter = DefaultReporter
 
+reporter.LineScanner     = LineScanner
+
 return reporter

--- a/tests/linescanner.lua
+++ b/tests/linescanner.lua
@@ -1,0 +1,183 @@
+-- Allow testing without installing,
+package.path = "src/?.lua;"..package.path
+
+local LineScanner = require("luacov.reporter").LineScanner
+
+local ntests = 0
+
+-- source must contain "+", "?" or "-" at the end of each line,
+-- marking expected output: "+" for always included lines, "?" for lines
+-- included when hit, "-" for excluded lines.
+local function test(source)
+   ntests = ntests + 1
+
+   local lines = {}
+   local failed = false
+   local scanner = LineScanner:new()
+
+   for line in source:gmatch("[^\n]+") do
+      local expected_symbol = line:sub(-1)
+      line = line:sub(1, -2)
+
+      local always_excluded, excluded_when_not_hit = scanner:consume(line)
+      local actual_symbol = always_excluded and "-" or (excluded_when_not_hit and "?" or "+")
+
+      if actual_symbol ~= expected_symbol then
+         failed = true
+      end
+
+      table.insert(lines, line..expected_symbol.." "..actual_symbol)
+   end
+
+   if failed then
+      error(("LineScanner test #%d failed!\nLine/expected/actual:\n\n%s"):format(
+         ntests, table.concat(lines, "\n")
+      ), 0)
+   end
+end
+
+-- Tests from tests/issue_1.lua:
+
+-- First line used to be annotated as excluded, but was not actually excluded.
+test [[
+   local thing = nil +
+   print("test1")    +
+]]
+
+test [[
+   local stuff = function (x) return x end +
+   local thing = stuff({                   +
+      b = { name = 'bob',                  ?
+      },                                   +
+      -- comment                           -
+   })                                      ?
+   print("test2")                          +
+]]
+
+test [[
+   local stuff = function (x) return x end +
+   local thing = stuff({                   +
+      b = { name = 'bob',                  ?
+      },                                   +
+      -- comment                           -
+   }                                       ?
+   )                                       ?
+   print("test2")                          +
+]]
+
+test [[
+   if true then      -
+      print("test3") +
+   end               -
+]]
+
+test [[
+   if true then      -
+   end               -
+   print("test3")    +
+]]
+
+
+test [[
+   while true do     -
+      print("test4") +
+      break          ?
+   end               -
+]]
+
+test [[
+   local a, b = 1,2 +
+   if               -
+      a < b         +
+   then             -
+      a = b         +
+   end              -
+   print("test7")   +
+]]
+
+test [[
+   local a,b = 1,2               +
+   if a < b then                 +
+      a = b                      +
+   end;                          -
+                                 -
+   local function foo(f) f() end +
+   foo(function()                +
+      a = b                      +
+   end)                          -
+                                 -
+   print("test8")                +
+]]
+
+test [[
+   local function foo(f) -
+      return function()  ?
+         a = a           +
+      end                -
+   end                   -
+   foo()()               +
+                         -
+   print("test9")        +
+]]
+
+-- Line 'c = 3' used to be annotated as excluded, but was not actually excluded.
+test [[
+   local s = {     +
+      a = 1;       ?
+      b = 2,       ?
+      c = 3        +
+   }               ?
+                   -
+   print("test10") +
+]]
+
+-- Line 'return 1, 2, function()' is supposed to be excluded,
+-- but corresponding exclusion rule is bugged, see #27.
+test [[
+   local function foo(f)      -
+      return 1, 2, function() +
+         a = a                +
+      end                     -
+   end                        -
+   local a,b,c = foo()        +
+   c()                        +
+                              -
+   print("test11")            +
+]]
+
+-- Issue #25.
+test [=[
+print([[         +
+some long string -
+]==]             -
+still going      -
+end]])           +
+]=]
+
+-- Inline long comments.
+test [=[
+local function foo(--[[unused]] x) -
+   return x                        +
+end                                -
+]=]
+
+-- Chaotic whitespace.
+test [=[
+  while     true     do -
+      end               -
+]=]
+
+-- Strange strings.
+test [=[
+local a = "[[\ +
+]]\            -
+print(b)"      +
+print(a)       +
+]=]
+
+test [=[
+local a = ("\     +
+local function(") +
+]=]
+
+print(("%d LineScanner tests passed."):format(ntests))

--- a/tests/linescanner.lua
+++ b/tests/linescanner.lua
@@ -145,13 +145,26 @@ test [[
    print("test11")            +
 ]]
 
--- Issue #25.
+-- Lines inside long strings.
 test [=[
 print([[         +
 some long string -
 ]==]             -
 still going      -
 end]])           +
+]=]
+
+-- Assignments of long strings.
+test [=[
+local s = [[ ?
+abc          -
+]]           +
+]=]
+
+test [=[
+t.k = [[ ?
+abc      -
+]]       +
 ]=]
 
 -- Inline long comments.
@@ -169,7 +182,7 @@ test [=[
 
 -- Strange strings.
 test [=[
-local a = "[[\ +
+local a = "[[\ ?
 ]]\            -
 print(b)"      +
 print(a)       +


### PR DESCRIPTION
Implemented a very relaxed lexer which splits lines into tokens and simplifies them (all numbers become `0`, string starts and ends become `'`, whitespace is collapsed into one space, comments are removed). As a result, strings containing special characters, e.g. something that looks like a comment start, are handled properly, and exclusion rules can be simplified.

This also fixes handling of comments and long string, see #25.

The lexer consumes lines and returns whether they should be always excluded or excluded if it's not hit. As it does not need hit stats, unlike whole reporter, it can be fully tested. I imported tests from tests/issue_1.lua and added a few new ones.