### PR TITLE
Add 'modules' option

### DIFF
--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -52,5 +52,19 @@ return {
     "luacov/tick$",
   },
 
+  -- Table mapping names of modules to be included to their filenames.
+  -- Has no effect if empty.
+  -- Real filenames mentioned here will be used for reporting
+  -- even if the modules have been installed elsewhere.
+  -- Module name can contain '*' wildcard to match groups of modules.
+  -- If a module or a group of modules is mapped to a directory (path ending
+  -- with a slash), it will be used as a prefix.
+  -- Example:
+  -- modules = {
+  --   ["some_rock"] = "src/some_rock.lua",
+  --   ["some_rock.*"] = "src/"
+  -- }
+  modules = {
+  },
 
 }

--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -56,13 +56,13 @@ return {
   -- Has no effect if empty.
   -- Real filenames mentioned here will be used for reporting
   -- even if the modules have been installed elsewhere.
-  -- Module name can contain '*' wildcard to match groups of modules.
-  -- If a module or a group of modules is mapped to a directory (path ending
-  -- with a slash), it will be used as a prefix.
+  -- Module name can contain '*' wildcard to match groups of modules,
+  -- in this case corresponding path will be used as a prefix directory
+  -- where modules from the group are located.
   -- Example:
   -- modules = {
   --   ["some_rock"] = "src/some_rock.lua",
-  --   ["some_rock.*"] = "src/"
+  --   ["some_rock.*"] = "src"
   -- }
   modules = {
   },

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -115,14 +115,15 @@ function ReporterBase:new(conf)
    local stats = require("luacov.stats")
 
    stats.statsfile = conf.statsfile
-   local data, most_hits = stats.load()
+   local data = stats.load()
 
    if not data then
-      return nil, "Could not load stats file " .. conf.statsfile .. ".", most_hits
+      return nil, "Could not load stats file " .. conf.statsfile .. "."
    end
 
    local files = {}
    local filtered_data = {}
+   local max_hits = 0
 
    -- Several original paths can map to one real path,
    -- their stats should be merged in this case.
@@ -136,6 +137,8 @@ function ReporterBase:new(conf)
             table.insert(files, filename)
             filtered_data[filename] = file_stats
          end
+
+         max_hits = math.max(max_hits, filtered_data[filename].max_hits)
       end
    end
 
@@ -149,7 +152,7 @@ function ReporterBase:new(conf)
       _cfg  = conf,
       _data = filtered_data,
       _files = files,
-      _mhit = most_hits,
+      _mhit = max_hits,
    }, self)
   
    return o

--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -103,12 +103,14 @@ end
 function runner.update_stats(old_stats, extra_stats)
    old_stats.max = math.max(old_stats.max, extra_stats.max)
 
-   -- Remove 'max' key so that it does not appear when iterating
+   -- Remove string keys so that they do not appear when iterating
    -- over 'extra_stats'.
    extra_stats.max = nil
+   extra_stats.max_hits = nil
       
    for line_nr, run_nr in pairs(extra_stats) do
       old_stats[line_nr] = (old_stats[line_nr] or 0) + run_nr
+      old_stats.max_hits = math.max(old_stats.max_hits, old_stats[line_nr])
    end
 end
 
@@ -138,13 +140,14 @@ local function on_line(_, line_nr)
 
    local file = data[name]
    if not file then
-      file = {max=0}
+      file = {max = 0, max_hits = 0}
       data[name] = file
    end
    if line_nr > file.max then
       file.max = line_nr
    end
    file[line_nr] = (file[line_nr] or 0) + 1
+   file.max_hits = math.max(file.max_hits, file[line_nr])
 end
 
 ------------------------------------------------------

--- a/src/luacov/stats.lua
+++ b/src/luacov/stats.lua
@@ -8,17 +8,19 @@ local stats = {}
 
 -----------------------------------------------------
 -- Loads the stats file.
--- @return table with data
--- @return hitcount of the line with the most hits (to provide the widest number format for reporting)
+-- @return table with data. The table maps filenames to stats tables.
+-- Per-file tables map line numbers to hits or nils when there are no hits.
+-- Additionally, .max field contains maximum line number
+-- and .max_hits contains maximum number of hits in the file.
 function stats.load()
-   local data, most_hits = {}, 0
+   local data = {}
    local fd = io.open(stats.statsfile, "r")
    if not fd then
       return nil
    end
    while true do
-      local nlines = fd:read("*n")
-      if not nlines then
+      local max = fd:read("*n")
+      if not max then
          break
       end
       local skip = fd:read(1)
@@ -30,9 +32,10 @@ function stats.load()
          break
       end
       data[filename] = {
-         max=nlines
+         max = max,
+         max_hits = 0
       }
-      for i = 1, nlines do
+      for i = 1, max do
          local hits = fd:read("*n")
          if not hits then
             break
@@ -43,12 +46,12 @@ function stats.load()
          end
          if hits > 0 then
             data[filename][i] = hits
-            most_hits = math.max(most_hits, hits)
+            data[filename].max_hits = math.max(data[filename].max_hits, hits)
          end
       end
    end
    fd:close()
-   return data, most_hits
+   return data
 end
 
 --------------------------------


### PR DESCRIPTION
Added new option for mapping module names to files where there are located. Modules are specified in the same way as in rockspecs, with a shortcut for many submodules:

```lua
modules = {
   ["rock.*"] = "src/"
}
```

instead of

```lua
modules = {
   ["rock.foo"] = "src/rock/foo.lua",
   ["rock.bar"] = "src/rock/bar.lua",
   ...
}
```

Module names are converted to patterns and added to `included` list automatically. When reporting, "real" filenames (values in the `modules` table) are used instead of original paths pointing to wherever luarocks installed them. So this addresses moteus/luacov-coveralls#2.