### PR TITLE
Fix crash when building report without config + other fixes

### DIFF
--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -280,7 +280,7 @@ function runner.load_config(configuration)
          if file_exists(runner.defaults.configfile) then
             set_config(dofile(runner.defaults.configfile))
          else
-            runner.configuration = runner.defaults
+            set_config(runner.defaults)
          end
       elseif type(configuration) == "string" then
          set_config(dofile(configuration))

--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -233,7 +233,7 @@ function runner.real_name(filename)
       if match then
          local new_filename = runner.modules.filenames[i]
 
-         if new_filename:find(wildcard_expansion) then
+         if pattern:find(wildcard_expansion, 1, true) then
             -- Given a prefix directory, join it
             -- with matched part of source file name.
             if not new_filename:match("/$") then


### PR DESCRIPTION
Introduced this one in #31, sorry. Since options require some post processing now `set_config` must be called even when loading default configuration, otherwise `runner.modules` is not initialized. Alternative would be to initialize it to an empty table in the main chunk but I think always using a single function for config loading is cleaner.