### PR TITLE
Fix multiline function declarations

### DIFF
--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -18,8 +18,8 @@ local fixups = {
    { "(", " ?%( ?" }, -- '(' may be surrounded by spaces
    { ")", " ?%) ?" }, -- ')' may be surrounded by spaces
    { "<ID>", "[%w_]+" }, -- identifier
-   { "<FULLID>", "[%w_][%w_%.%[%]]+" }, -- identifier, possibly indexed
-   { "<IDS>", "[%w_, ]+" }, -- comma-separated identifiers
+   { "<FULLID>", "[%w_]+[%[%.]?[%w_']*%]?" }, -- identifier, possibly indexed once
+   { "<IDS>", "[%w_ ]+,[%w_, ]+" }, -- at least two comma-separated identifiers
    { "<ARGS>", "[%w_, '%.]*" }, -- comma-separated arguments
    { "<FIELDNAME>", "%[? ?['%w_]+ ?%]?" }, -- field, possibly like ["this"]
 }
@@ -44,6 +44,8 @@ local any_hits_exclusions = {
    "then", -- Single "then"
    "while true do", -- "while true do" generates no code
    "if true then", -- "if true then" generates no code
+   fixup "local <ID>", -- "local var"
+   fixup "local <ID>=", -- "local var ="
    fixup "local <IDS>", -- "local var1, ..., varN"
    fixup "local <IDS>=", -- "local var1, ..., varN ="
    fixup "local function <ID>", -- "local function f (arg1, ..., argN)"

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -46,22 +46,21 @@ local any_hits_exclusions = {
    "if true then", -- "if true then" generates no code
    fixup "local <IDS>", -- "local var1, ..., varN"
    fixup "local <IDS>=", -- "local var1, ..., varN ="
-   fixup "local function(<ARGS>)", -- "local function(arg1, ..., argN)"
-   fixup "local function <ID>(<ARGS>)", -- "local function f (arg1, ..., argN)"
+   fixup "local function <ID>", -- "local function f (arg1, ..., argN)"
 }
 
 --- Lines that are only excluded from accounting when they have 0 hits
 local zero_hits_exclusions = {
    "[%w_,=' ]+,", -- "var1 var2," multi columns table stuff
    fixup "<FIELDNAME>=.+[,;]", -- "[123] = 23," "['foo'] = "asd","
-   fixup "<ARGS>*function(<ARGS>)", -- "1,2,function(...)"
-   fixup "return <ARGS>*function(<ARGS>)", -- "return 1,2,function(...)"
-   fixup "return function(<ARGS>)", -- "return function(arg1, ..., argN)"
-   fixup "function(<ARGS>)", -- "function(arg1, ..., argN)"
-   fixup "local <ID>=function(<ARGS>)", -- "local a = function(arg1, ..., argN)"
+   fixup "<ARGS>*function", -- "1,2,function(...)"
+   fixup "return <ARGS>*function", -- "return 1,2,function(...)"
+   "return function", -- "return function(arg1, ..., argN)"
+   "function", -- "function(arg1, ..., argN)"
+   fixup "local <ID>=function", -- "local a = function(arg1, ..., argN)"
    fixup "local <ID>='", -- local a = [[
    fixup "<FULLID>='", -- a.b = [[
-   fixup "<FULLID>=function(<ARGS>)", -- "a = function(arg1, ..., argN)"
+   fixup "<FULLID>=function", -- "a = function(arg1, ..., argN)"
    "break", -- "break" generates no trace in Lua 5.2+
    "{", -- "{" opening table
    "}?[ %)]*", -- optional "{" closing table, possibly with several closing parens
@@ -81,7 +80,7 @@ local LineScanner = {} do
 LineScanner.__index = LineScanner
 
 function LineScanner:new()
-   return setmetatable({first = true, comment = false}, self)
+   return setmetatable({first = true, comment = false, after_function = false}, self)
 end
 
 function LineScanner:find(pattern)
@@ -128,6 +127,20 @@ function LineScanner:skip_long_string()
    end
 end
 
+-- Skips function arguments.
+-- @return boolean indicating success.
+function LineScanner:skip_args()
+   local _, paren_i = self:find("%)")
+
+   if paren_i then
+      self.i = paren_i + 1
+      self.args = nil
+      return true
+   else
+      return false
+   end
+end
+
 function LineScanner:skip_whitespace()
    local next_i = self:find("%S") or #self.line + 1
 
@@ -161,6 +174,11 @@ function LineScanner:skip_name()
    local _, _, name = self:find("^([%w_]*)")
    self.i = self.i + #name
    table.insert(self.simple_line_buffer, name)
+
+   if name == "function" then
+      -- This flag indicates that the next pair of parentheses (function args) must be skipped.
+      self.after_function = true
+   end
 end
 
 -- Consumes and analyzes a line.
@@ -182,6 +200,7 @@ function LineScanner:consume(line)
    -- Literal strings are replaced with "''", so that a string literal
    -- containing special characters does not confuse exclusion rules.
    -- Numbers are replaced with "0".
+   -- Function declaration arguments are removed.
    self.simple_line_buffer = {}
    self.i = 1
 
@@ -196,6 +215,11 @@ function LineScanner:consume(line)
       elseif self.equals then
          if not self:skip_long_string() then
             -- Long string literal or comment ends on another line.
+            break
+         end
+      elseif self.args then
+         if not self:skip_args() then
+            -- Function arguments end on another line.
             break
          end
       else
@@ -243,6 +267,10 @@ function LineScanner:consume(line)
                   if char == "'" or char == '"' then
                      table.insert(self.simple_line_buffer, "'")
                      self.quote = char
+                  elseif self.after_function and char == "(" then
+                     -- This is the opening parenthesis of function declaration args.
+                     self.after_function = false
+                     self.args = true
                   else
                      -- Save other punctuation literally.
                      -- This inserts an empty string when at the end of line,

--- a/tests/linescanner.lua
+++ b/tests/linescanner.lua
@@ -162,9 +162,27 @@ abc          -
 ]=]
 
 test [=[
+s = [[ ?
+abc    -
+]]     +
+]=]
+
+test [=[
 t.k = [[ ?
 abc      -
 ]]       +
+]=]
+
+test [=[
+t.k1.k2 = [[ +
+abc          -
+]]           +
+]=]
+
+test [=[
+t["k"] = [[ ?
+abc         -
+]]          +
 ]=]
 
 -- Inline long comments.
@@ -214,6 +232,17 @@ local function fff  -
       (a, b, c)     -
    return a + b + c +
 end                 -
+]]
+
+-- Local declarations
+test [[
+local function f() end +
+local x                -
+local x, y             -
+local x =              -
+1                      +
+local x, y =           -
+2, 3                   +
 ]]
 
 print(("%d LineScanner tests passed."):format(ntests))

--- a/tests/linescanner.lua
+++ b/tests/linescanner.lua
@@ -193,4 +193,27 @@ local a = ("\     +
 local function(") +
 ]=]
 
+-- Incomplete function declarations.
+test [[
+local function fff(a, -
+   b,                 -
+   c)                 -
+   return a + b + c   +
+end                   -
+]]
+
+test [[
+local function fff( -
+      a, b, c)      -
+   return a + b + c +
+end                 -
+]]
+
+test [[
+local function fff  -
+      (a, b, c)     -
+   return a + b + c +
+end                 -
+]]
+
 print(("%d LineScanner tests passed."):format(ntests))


### PR DESCRIPTION
In function declarations argument list never affects coverage. In this patch, arguments are simply removed during line simplification. Fixes exclusion rules not being properly applied when argument list spans several lines.

Follow up commit fixes an issue added in the first one - without argument lists `local function noop() end` matched `local <IDS>` exclusion rule. As a side effect function declarations with assignments to string literal indexes are properly excluded, e.g. `a["b"] = function(...)` is filtered out.

Added tests with samples of some of fixed issues.