### PR TITLE
Reduce default config size

### DIFF
--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -6,10 +6,6 @@
 -- @name luacov.defaults
 return {
 
-  -- default filename to load for config options if not provided
-  -- only has effect in 'luacov.defaults.lua'
-  ["configfile"] = ".luacov",
-
   -- filename to store stats collected
   ["statsfile"] = "luacov.stats.out",
 

--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -40,12 +40,6 @@ return {
   -- (exclude overrules include, do not include
   -- the .lua extension, path separator is always '/')
   ["exclude"] = {
-    "luacov$",
-    "luacov/reporter$",
-    "luacov/defaults$",
-    "luacov/runner$",
-    "luacov/stats$",
-    "luacov/tick$",
   },
 
   -- Table mapping names of modules to be included to their filenames.

--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -266,6 +266,8 @@ local function set_config(configuration)
    acknowledge_modules()
 end
 
+local default_config_file = ".luacov"
+
 ------------------------------------------------------
 -- Loads a valid configuration.
 -- @param configuration user provided config (config-table or filename)
@@ -277,8 +279,8 @@ function runner.load_config(configuration)
    if not runner.configuration then
       if not configuration then
          -- nothing provided, load from default location if possible
-         if file_exists(runner.defaults.configfile) then
-            set_config(dofile(runner.defaults.configfile))
+         if file_exists(default_config_file) then
+            set_config(dofile(default_config_file))
          else
             set_config(runner.defaults)
          end

--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -251,6 +251,17 @@ function runner.real_name(filename)
    return orig_filename
 end
 
+-- Always exclude luacov's own files.
+local luacov_excludes = {
+   "luacov$",
+   "luacov/reporter$",
+   "luacov/reporter/default$",
+   "luacov/defaults$",
+   "luacov/runner$",
+   "luacov/stats$",
+   "luacov/tick$"
+}
+
 -- Sets configuration. If some options are missing, default values are used instead.
 local function set_config(configuration)
    runner.configuration = {}
@@ -264,6 +275,10 @@ local function set_config(configuration)
    end
 
    acknowledge_modules()
+
+   for _, patt in ipairs(luacov_excludes) do
+      table.insert(runner.configuration.exclude, patt)
+   end
 end
 
 local default_config_file = ".luacov"


### PR DESCRIPTION
It's probably a good idea to shrink the size of luacov.defaults as they are supposed to be copied by user:

* `configfile` is useless for user, move into luacov.runner.
* Default `exclude` patterns match luacov own files, it makes sense to always exclude them - move logic into luacov.runner.

Not pushing this directly as it's technically an interface change.
