### PR TITLE
Remove './' prefix from the source filename.

### DIFF
--- a/src/luacov/hook.lua
+++ b/src/luacov/hook.lua
@@ -27,6 +27,13 @@ function hook.new(runner)
       local prefixed_name = string.match(name, "^@(.*)")
       if prefixed_name then
          name = prefixed_name
+
+         local first, second = name:byte(1, 2)
+         -- '.' => 46, '/' => 47, '\' -> 92
+         if first == 46 and (second == 47 or second == 92) then
+            name = name:sub(3)
+         end
+
       elseif not runner.configuration.codefromstrings then
          -- Ignore Lua code loaded from raw strings by default.
          return


### PR DESCRIPTION
The source filename will contain a './' prefix if they are run like
`lua -lluacov ./x.lua`.

As a result, if we run `lua -lluacov x.lua`, the `luacov.stats.out` is:
1:x.lua
1

However, if we run `lua -lluacov ./x.lua`, the `luacov.stats.out` is:
1:./x.lua
1

So the result could be inconsistent even we run in the same root directory of
the same project, which brings extra challenge to develop a custom reporter.