### PR TITLE
add option to include untested files in report

### DIFF
--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -66,4 +66,8 @@ return {
   -- }
   modules = {},
 
+  --- Enable including untested files in report.
+  -- Default: false.
+  includeuntestedfiles = false,
+
 }

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -40,7 +40,7 @@ end
 --- @param filename
 --- @param pattern
 --- @return boolean
-local function fileMaches(filename, pattern)
+local function fileMatches(filename, pattern)
    return string.find(filename, pattern)
 end
 
@@ -91,7 +91,7 @@ function ReporterBase:new(conf)
    -- only .lua files
    if conf.includeuntestedfiles then
       for filename, attr in dirtree("./") do
-         if attr.mode == "file" and fileMaches(filename, '.%.lua$') then
+         if attr.mode == "file" and fileMatches(filename, '.%.lua$') then
             local file_stats = {}
             file_stats[0] = 0
             if luacov.file_included(filename) then

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -7,22 +7,22 @@ local reporter = {}
 local LineScanner = require("luacov.linescanner")
 local luacov = require("luacov.runner")
 local util = require("luacov.util")
-require "lfs"
+local lfs = require("lfs")
 
 ----------------------------------------------------------------
 --- returns all files inside dir
 --- @param dir directory to be listed
 --- @treturn table with filenames and attributes
-function dirtree(dir)
+local function dirtree(dir)
    assert(dir and dir ~= "", "Please pass directory parameter")
    if string.sub(dir, -1) == "/" then
        dir=string.sub(dir, 1, -2)
    end
 
-   local function yieldtree(dir)
-       for entry in lfs.dir(dir) do
+   local function yieldtree(directory)
+       for entry in lfs.dir(directory) do
            if entry ~= "." and entry ~= ".." then
-               entry=dir.."/"..entry
+               entry=directory.."/"..entry
                local attr=lfs.attributes(entry)
                coroutine.yield(entry,attr)
                if attr.mode == "directory" then
@@ -40,7 +40,7 @@ end
 --- @param filename
 --- @param pattern
 --- @return boolean
-function fileMaches(filename, pattern)
+local function fileMaches(filename, pattern)
    return string.find(filename, pattern)
 end
 


### PR DESCRIPTION
this resolves the issue #70 
- feature that includes all files .lua within the directory (not only the ones touched by tests)
- new option in config file to enable this feature (default is disabled)