### PR TITLE
Added reporting untested file feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - source lua_install/bin/activate
   - luarocks install busted
   - luarocks install luacheck
+  - luarocks install luafilesystem 
   - luarocks install cluacov --deps-mode=none
 
 install:

--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -17,6 +17,9 @@ return {
   -- using `luacov.tick` module. Default: false.
   tick = false,
 
+  --- Include all files including untested ones in the report 
+  includeuntested = false,
+
   --- Stats file updating frequency for `luacov.tick`.
   -- The lower this value - the more frequently results will be written out to the stats file.
   -- You may want to reduce this value (to, for example, 2) to avoid losing coverage data in
@@ -34,6 +37,7 @@ return {
   -- That is, when the 'source' field in the debug info
   -- does not start with '@'. Default: false.
   codefromstrings = false,
+
 
   --- Lua patterns for files to include when reporting.
   -- All will be included if nothing is listed.

--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -17,7 +17,11 @@ return {
   -- using `luacov.tick` module. Default: false.
   tick = false,
 
+<<<<<<< HEAD
+  --- Include all files including untested ones in the report
+=======
   --- Include all files including untested ones in the report 
+>>>>>>> dd87bce... Added reporting untested file feature
   includeuntested = false,
 
   --- Stats file updating frequency for `luacov.tick`.

--- a/src/luacov/defaults.lua
+++ b/src/luacov/defaults.lua
@@ -17,11 +17,7 @@ return {
   -- using `luacov.tick` module. Default: false.
   tick = false,
 
-<<<<<<< HEAD
   --- Include all files including untested ones in the report
-=======
-  --- Include all files including untested ones in the report 
->>>>>>> dd87bce... Added reporting untested file feature
   includeuntested = false,
 
   --- Stats file updating frequency for `luacov.tick`.

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -35,7 +35,6 @@ function ReporterBase:new(conf)
    local filtered_data = {}
    local max_hits = 0
 
-   
    -- Several original paths can map to one real path,
    -- their stats should be merged in this case.
    for filename, file_stats in pairs(data) do
@@ -55,7 +54,6 @@ function ReporterBase:new(conf)
       end
    end
 
-<<<<<<< HEAD
    -- Add untested files to the files table
    if conf.includeuntested then
       for entry in lfs.dir(lfs.currentdir()) do
@@ -70,26 +68,6 @@ function ReporterBase:new(conf)
             end
          end
       end
-=======
-   
-   -- Add untested files to the files table 
-   if conf.includeuntested then
-      
-      for entry in lfs.dir(lfs.currentdir()) do
-         
-         if string.find(entry,"%.lua$") then
-            if luacov.file_included(entry) then 
-               realname = luacov.real_name(entry)
-            
-
-               if not filtered_data[realname] then 
-                  table.insert(files,realname)
-                  filtered_data[realname] = {0}
-               end      
-            end
-         end
-      end         
->>>>>>> dd87bce... Added reporting untested file feature
    end
 
    table.sort(files)

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -55,6 +55,22 @@ function ReporterBase:new(conf)
       end
    end
 
+<<<<<<< HEAD
+   -- Add untested files to the files table
+   if conf.includeuntested then
+      for entry in lfs.dir(lfs.currentdir()) do
+         if string.find(entry,"%.lua$") then
+            if luacov.file_included(entry) then
+               local realname = luacov.real_name(entry)
+
+               if not filtered_data[realname] then
+                  table.insert(files,realname)
+                  filtered_data[realname] = {0}
+               end
+            end
+         end
+      end
+=======
    
    -- Add untested files to the files table 
    if conf.includeuntested then
@@ -73,6 +89,7 @@ function ReporterBase:new(conf)
             end
          end
       end         
+>>>>>>> dd87bce... Added reporting untested file feature
    end
 
    table.sort(files)

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -7,6 +7,7 @@ local reporter = {}
 local LineScanner = require("luacov.linescanner")
 local luacov = require("luacov.runner")
 local util = require("luacov.util")
+local lfs = require("lfs")
 
 ----------------------------------------------------------------
 --- Basic reporter class stub.
@@ -34,9 +35,12 @@ function ReporterBase:new(conf)
    local filtered_data = {}
    local max_hits = 0
 
+   
    -- Several original paths can map to one real path,
    -- their stats should be merged in this case.
    for filename, file_stats in pairs(data) do
+
+
       if luacov.file_included(filename) then
          filename = luacov.real_name(filename)
 
@@ -49,6 +53,26 @@ function ReporterBase:new(conf)
 
          max_hits = math.max(max_hits, filtered_data[filename].max_hits)
       end
+   end
+
+   
+   -- Add untested files to the files table 
+   if conf.includeuntested then
+      
+      for entry in lfs.dir(lfs.currentdir()) do
+         
+         if string.find(entry,"%.lua$") then
+            if luacov.file_included(entry) then 
+               realname = luacov.real_name(entry)
+            
+
+               if not filtered_data[realname] then 
+                  table.insert(files,realname)
+                  filtered_data[realname] = {0}
+               end      
+            end
+         end
+      end         
    end
 
    table.sort(files)


### PR DESCRIPTION
Solves the issue #70 by adding an option in config files
Works by adding all files that aren't tested in the directory to the reporter and calculate the percentage of total hits.