### PR TITLE
Allow to use with Lua 5.4

### DIFF
--- a/luacov-scm-1.rockspec
+++ b/luacov-scm-1.rockspec
@@ -17,7 +17,7 @@ effectiveness of a test suite.
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, < 5.4"
+   "lua >= 5.1"
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
LuaCov seems to work fine with Lua 5.4 as stated in #83
When reviewing this, also consider reviewing cluacov PR https://github.com/luarocks/cluacov/pull/2
