### PR TITLE
Fix include untested files

### DIFF
--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -97,8 +97,10 @@ function ReporterBase:new(conf)
       for filename, attr in dirtree("./") do
          filename = filename:gsub("^%./", "")
          if attr.mode == "file" and fileMatches(filename, '.%.lua$') then
-            local file_stats = {}
-            file_stats[0] = 0
+            local file_stats = {
+               max = 0,
+               max_hits = 0
+            }
             if luacov.file_included(filename) then
                filename = luacov.real_name(filename)
 

--- a/src/luacov/reporter.lua
+++ b/src/luacov/reporter.lua
@@ -95,6 +95,7 @@ function ReporterBase:new(conf)
          os.exit(1)
       end
       for filename, attr in dirtree("./") do
+         filename = filename:gsub("^%./", "")
          if attr.mode == "file" and fileMatches(filename, '.%.lua$') then
             local file_stats = {}
             file_stats[0] = 0


### PR DESCRIPTION
I encountered a few issues caused by the recent addition of the `includeuntestedfiles` configuration option.
- The filenames included by this option had a `./` prefix that caused them not to match with files already added
- The stats object for untested files did not match the structure of stats objects for tested files
