### PR TITLE
disable hooks before aggregating stats

### DIFF
--- a/src/luacov/runner.lua
+++ b/src/luacov/runner.lua
@@ -141,6 +141,8 @@ local function on_exit()
    -- so this method could be called twice
    if on_exit_run_once then return end
    on_exit_run_once = true
+   -- disable hooks before aggregating stats
+   debug.sethook(nil)
    runner.save_stats()
 
    if runner.configuration.runreport then


### PR DESCRIPTION
Encountered a situation with a custom LuaJit stuck at Lua 5.1 level, where we emulate the 5.2 custom metatable iterator support by replacing global `next`, `pairs`, and `ipairs` with our own shims. This had the side effect of triggering the LuaCov hook during shutdown whenever the stats aggregation or serialization loops through a table. (for those interested: the crash surfaced as an integer comparison with nil somewhere in the hook callback).

Disabling the hooks in the `on_exit` function before the stats update happens seems to avoid this nicely.